### PR TITLE
docs: Se ajusta el readme adjuntando la documentacion

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # notificacion_mid
 Servicio para envío de notificaciónes por difusión en AWS SNS.
 
-Para instrucciones de implementación del sistema de notificaciones consulta la [documentacion](https://drive.google.com/file/d/1ZlXdKAyooyftamyCZX8Btmd5nhDR5YEX/view?usp=drivesdk
-)
+Para instrucciones de implementación del sistema de notificaciones consulta la [documentacion](https://drive.google.com/file/d/1ZlXdKAyooyftamyCZX8Btmd5nhDR5YEX/view?usp=drivesdk)
 
 ## Especificaciones Técnicas
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # notificacion_mid
-Servicio para envío de notificaciónes por difusión en AWS SNS
+Servicio para envío de notificaciónes por difusión en AWS SNS.
+
+Para instrucciones de implementación del sistema de notificaciones consulta la [documentacion](https://drive.google.com/file/d/1ZlXdKAyooyftamyCZX8Btmd5nhDR5YEX/view?usp=drivesdk
+)
 
 ## Especificaciones Técnicas
 

--- a/controllers/colas.go
+++ b/controllers/colas.go
@@ -97,8 +97,8 @@ func (c *ColasController) RecibirMensajes() {
 	}
 
 	numMaxStr := c.GetString("numMax")
-	if tiempoOcultoStr == "" {
-		tiempoOcultoStr = "1"
+	if numMaxStr == "" {
+		numMaxStr = "1"
 	}
 
 	numMax, err := strconv.Atoi(numMaxStr)


### PR DESCRIPTION
Se ajustó el readme para poder tener la documentación en el repositorio y se corrigió un error con un atributo de recepción de mensajes que hacía que el número máximo fuera obligatorio.