### PR TITLE
fix: Cambio de métodos delete por post

### DIFF
--- a/controllers/colas.go
+++ b/controllers/colas.go
@@ -122,7 +122,7 @@ func (c *ColasController) RecibirMensajes() {
 // @Param	mensaje		body 	models.Mensaje	true		"Mensaje a borrar"
 // @Success 200 {string} Mensaje eliminado
 // @Failure 404 not found resource
-// @router /mensajes/:cola [delete]
+// @router /mensajes/:cola [post]
 func (c *ColasController) BorrarMensaje() {
 	colaStr := c.Ctx.Input.Param(":cola")
 	var mensaje models.Mensaje
@@ -160,7 +160,7 @@ func (c *ColasController) BorrarMensaje() {
 // @Param	filtro		body 	models.Filtro		true		"Filtro de los mensajes a borrar"
 // @Success 200 {string} Mensaje eliminado
 // @Failure 404 not found resource
-// @router /mensajes [delete]
+// @router /mensajes [post]
 func (c *ColasController) BorrarMensajeFiltro() {
 	var filtro models.Filtro
 

--- a/routers/commentsRouter_controllers.go
+++ b/routers/commentsRouter_controllers.go
@@ -38,7 +38,7 @@ func init() {
         beego.ControllerComments{
             Method: "BorrarMensajeFiltro",
             Router: "/mensajes",
-            AllowHTTPMethods: []string{"delete"},
+            AllowHTTPMethods: []string{"post"},
             MethodParams: param.Make(),
             Filters: nil,
             Params: nil})
@@ -47,7 +47,7 @@ func init() {
         beego.ControllerComments{
             Method: "BorrarMensaje",
             Router: "/mensajes/:cola",
-            AllowHTTPMethods: []string{"delete"},
+            AllowHTTPMethods: []string{"post"},
             MethodParams: param.Make(),
             Filters: nil,
             Params: nil})

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -114,7 +114,7 @@
                     }
                 }
             },
-            "delete": {
+            "post": {
                 "tags": [
                     "colas"
                 ],
@@ -142,7 +142,7 @@
             }
         },
         "/colas/mensajes/{cola}": {
-            "delete": {
+            "post": {
                 "tags": [
                     "colas"
                 ],
@@ -351,15 +351,15 @@
             "title": "string",
             "type": "object"
         },
-        "1159.0xc000514d20.false": {
+        "1159.0xc0005ba3c0.false": {
             "title": "false",
             "type": "object"
         },
-        "1849.0xc000514ed0.false": {
+        "1849.0xc0005ba570.false": {
             "title": "false",
             "type": "object"
         },
-        "2469.0xc0005150e0.false": {
+        "2469.0xc0005ba780.false": {
             "title": "false",
             "type": "object"
         },
@@ -455,7 +455,7 @@
                     }
                 },
                 "Body": {
-                    "$ref": "#/definitions/1159.0xc000514d20.false"
+                    "$ref": "#/definitions/1159.0xc0005ba3c0.false"
                 },
                 "ReceiptHandle": {
                     "type": "string"
@@ -473,7 +473,7 @@
                     "type": "string"
                 },
                 "Atributos": {
-                    "$ref": "#/definitions/1849.0xc000514ed0.false"
+                    "$ref": "#/definitions/1849.0xc0005ba570.false"
                 },
                 "DestinatarioId": {
                     "type": "array",
@@ -505,7 +505,7 @@
                 "Statement": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/2469.0xc0005150e0.false"
+                        "$ref": "#/definitions/2469.0xc0005ba780.false"
                     }
                 },
                 "Version": {

--- a/swagger/swagger.yml
+++ b/swagger/swagger.yml
@@ -79,7 +79,7 @@ paths:
             $ref: '#/definitions/models.Mensaje'
         "400":
           description: Error en parametros ingresados
-    delete:
+    post:
       tags:
       - colas
       description: Borra la notificación de la cola según el key y el valor ingresados
@@ -98,7 +98,7 @@ paths:
         "404":
           description: not found resource
   /colas/mensajes/{cola}:
-    delete:
+    post:
       tags:
       - colas
       description: Borra la notificación de la cola
@@ -235,13 +235,13 @@ definitions:
   1083.<nil>.string:
     title: string
     type: object
-  1159.0xc000514d20.false:
+  1159.0xc0005ba3c0.false:
     title: "false"
     type: object
-  1849.0xc000514ed0.false:
+  1849.0xc0005ba570.false:
     title: "false"
     type: object
-  2469.0xc0005150e0.false:
+  2469.0xc0005ba780.false:
     title: "false"
     type: object
   map[string]interface{Success:
@@ -309,7 +309,7 @@ definitions:
         additionalProperties:
           type: string
       Body:
-        $ref: '#/definitions/1159.0xc000514d20.false'
+        $ref: '#/definitions/1159.0xc0005ba3c0.false'
       ReceiptHandle:
         type: string
   models.Notificacion:
@@ -321,7 +321,7 @@ definitions:
       Asunto:
         type: string
       Atributos:
-        $ref: '#/definitions/1849.0xc000514ed0.false'
+        $ref: '#/definitions/1849.0xc0005ba570.false'
       DestinatarioId:
         type: array
         items:
@@ -343,7 +343,7 @@ definitions:
       Statement:
         type: array
         items:
-          $ref: '#/definitions/2469.0xc0005150e0.false'
+          $ref: '#/definitions/2469.0xc0005ba780.false'
       Version:
         type: string
   models.Suscripcion:


### PR DESCRIPTION
Ya que en autenticación no se puede enviar contenido en body por un método delete, se cambia este método por un post para eliminar mensajes de las colas.